### PR TITLE
GitHub Actions の Slack 通知で `github.workflow` を使用

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         uses: homoluctus/slatify@v1.5
         if: always()
         with:
-          job_name: '*Node CI*'
+          job_name: '*${{ github.workflow }}*'
           type: ${{ job.status }}
           icon_emoji: ":octocat:"
           url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## 概要

GitHub Actions の Slack 通知部分で `github.workflow` コンテキストを使用

## 変更内容

`.github/workflows/main.yml` の `Slack Notification` 部分で `github.workflow` を使用するように変更

## 影響範囲

なし

## 動作要件

なし

## 補足

なし