### PR TITLE
GitHub Actions の `jobs.steps.name` を削除

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,18 +18,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Run yarn install
-        run: yarn install
+      - run: yarn install
         env:
           CI: true
 
-      - name: Run yarn build
-        run: yarn run build
+      - run: yarn run build
         env:
           CI: true
 
-      - name: Run yarn lint
-        run: yarn run lint
+      - run: yarn run lint
         env:
           CI: true
 


### PR DESCRIPTION
## 概要

GitHub Actions の `jobs.steps.name` を削除. コマンド実行のステップは, `name` を省略した場合は自動でコマンドがステップ名になるため, 省略する.

削除対象はコマンドの実行のみのステップで,  `actions/checkout` や Slack 通知は削除しない

## 変更内容

`.github/workflows/main.yml` の `jobs.steps.name` を削除

## 影響範囲

なし

## 動作要件

なし

## 補足

なし