### PR TITLE
リンクに擬似クラスを追加

### DIFF
--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -14,6 +14,7 @@
           :href="link.to"
           target="_blank"
           rel="noopener noreferrer"
+          class="links-list-item-link"
         >
         </a>
       </li>
@@ -40,8 +41,19 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .links-list-item {
   border-left: solid 0.5rem #ffa44b;
+}
+
+.links-list-item-link {
+  &:hover {
+    color: #1B64DF;
+  }
+
+  &:active {
+    background-color: #7f828b;
+    color: #ffffff;
+  }
 }
 </style>

--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -42,6 +42,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+$link-opacity: 0.6;
+
 .links-list-item {
   border-left: solid 0.5rem #ffa44b;
 }
@@ -49,11 +51,13 @@ export default Vue.extend({
 .links-list-item-link {
   &:hover {
     color: #1B64DF;
+    opacity: $link-opacity;
   }
 
   &:active {
     background-color: #7f828b;
     color: #ffffff;
+    opacity: $link-opacity;
   }
 }
 </style>

--- a/components/ProjectItem.vue
+++ b/components/ProjectItem.vue
@@ -13,7 +13,7 @@
         <a
           v-for="(link, projectLinksKey) in project.links"
           :key="projectLinksKey"
-          class="project-attributes bg-blue-500 rounded font-source-sans-pro"
+          class="project-attributes project-link-item bg-blue-500 rounded font-source-sans-pro"
           v-text="link.name"
           :href="link.to"
           target="_blank"
@@ -57,8 +57,21 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+$link-opacity: 0.6;
+
 .project-attributes {
   @apply text-sm text-white font-semibold inline-block px-3 py-1 mr-2 mb-2;
+}
+
+.project-link-item {
+  &:hover {
+    opacity: $link-opacity;
+  }
+
+  &:active {
+    background-color: #38c3e1;
+    opacity: $link-opacity;
+  }
 }
 </style>


### PR DESCRIPTION
## 概要

サイト内のリンク部分に擬似クラスを追加.

## 変更内容

`LinkList` と `ProjectItem` コンポーネントの `<style>` に擬似クラスを追加.
SCSSを使用する.

## 影響範囲

なし

## 動作要件

なし

## 補足

なし