### PR TITLE
SFC で Composition API を使うように変更

### DIFF
--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -23,20 +23,31 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import { createComponent } from '@vue/composition-api';
 import { Link } from '~/types';
 
-export default Vue.extend({
+interface Props {
+  title: string;
+  links: Link[];
+}
+
+export default createComponent({
   name: 'LinkList',
   props: {
     title: {
       type: String,
       required: true,
-    } as PropOptions<string>,
+    },
     links: {
       type: Array,
       required: true,
-    } as PropOptions<Link[]>,
+    },
+  },
+  setup (props: Props) {
+    return {
+      title: props.title,
+      links: props.links,
+    };
   },
 });
 </script>

--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -43,12 +43,6 @@ export default createComponent({
       required: true,
     },
   },
-  setup (props: Props) {
-    return {
-      title: props.title,
-      links: props.links,
-    };
-  },
 });
 </script>
 

--- a/components/LinksContent.vue
+++ b/components/LinksContent.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { createComponent, computed } from '@vue/composition-api';
 import LinkList from './LinkList';
 import { Link } from '~/types';
 
@@ -27,29 +27,13 @@ interface LinkListProperty {
   links: Link[];
 }
 
-export default Vue.extend({
+export default createComponent({
   name: 'LinksContent',
   components: {
     LinkList,
   },
-  computed: {
-    linkLists (): LinkListProperty[] {
-      return [
-        {
-          title: 'Social',
-          links: this.socialServiceLinks,
-        },
-        {
-          title: 'Sub domains',
-          links: this.subDomainLinks,
-        },
-        {
-          title: 'Blogs',
-          links: this.blogLinks,
-        },
-      ];
-    },
-    socialServiceLinks (): Link[] {
+  setup () {
+    const socialServiceLinks = computed<Link[]>((): Link[] => {
       return [
         {
           name: 'Twitter (hiroto_k_)',
@@ -64,8 +48,9 @@ export default Vue.extend({
           to: 'https://gitlab.com/hiroxto',
         },
       ];
-    },
-    subDomainLinks (): Link[] {
+    });
+
+    const subDomainLinks = computed<Link[]>((): Link[] => {
       return [
         {
           name: 'utils.hiroto-k.net',
@@ -76,8 +61,9 @@ export default Vue.extend({
           to: 'https://train-photo-blog.hiroto-k.net/',
         },
       ];
-    },
-    blogLinks (): Link[] {
+    });
+
+    const blogLinks = computed<Link[]>((): Link[] => {
       return [
         {
           name: 'Main blog',
@@ -88,7 +74,28 @@ export default Vue.extend({
           to: 'https://train-photo-blog.hiroto-k.net/',
         },
       ];
-    },
+    });
+
+    const linkLists = computed((): LinkListProperty[] => {
+      return [
+        {
+          title: 'Social',
+          links: socialServiceLinks.value,
+        },
+        {
+          title: 'Sub domains',
+          links: subDomainLinks.value,
+        },
+        {
+          title: 'Blogs',
+          links: blogLinks.value,
+        },
+      ];
+    });
+
+    return {
+      linkLists,
+    };
   },
 });
 </script>

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -9,9 +9,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { createComponent } from '@vue/composition-api';
 
-export default Vue.extend({
+export default createComponent({
   name: 'PageFooter',
 });
 </script>

--- a/components/ProfileContent.vue
+++ b/components/ProfileContent.vue
@@ -13,7 +13,7 @@
     </div>
 
     <div class="mt-4 md:mt-0 md:ml-6">
-      <p class="text-2xl text-gray-900 font-bold pb-4 font-source-sans-pro" v-text="names">
+      <p class="text-2xl text-gray-900 font-bold pb-4 font-source-sans-pro" v-text="name">
       </p>
 
       <profile-item title="Likes" :single-text="true">

--- a/components/ProfileContent.vue
+++ b/components/ProfileContent.vue
@@ -67,22 +67,18 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { createComponent, computed } from '@vue/composition-api';
 import ProfileItem from './ProfileItem';
 
-export default Vue.extend({
+export default createComponent({
   name: 'ProfileContent',
   components: {
     ProfileItem,
   },
-  computed: {
-    names (): string {
-      return 'hiroto-k / hiroxto';
-    },
-    joinSeparator (): string {
-      return ', ';
-    },
-    likes (): string {
+  setup () {
+    const name = computed<string>(() => 'hiroto-k / hiroxto');
+    const joinSeparator = ', ';
+    const likes = computed<string>(() => {
       return [
         'プログラミング',
         'アニメ',
@@ -91,9 +87,9 @@ export default Vue.extend({
         '写真',
         'ラーメン',
         'etc...',
-      ].join(this.joinSeparator);
-    },
-    programming (): string {
+      ].join(joinSeparator);
+    });
+    const programming = computed<string>(() => {
       return [
         'PHP',
         'Ruby',
@@ -101,9 +97,9 @@ export default Vue.extend({
         'Laravel',
         'Vue.js',
         'Nuxt.js',
-      ].join(this.joinSeparator);
-    },
-    voiceActorNames (): string[] {
+      ].join(joinSeparator);
+    });
+    const voiceActorNames = computed<string[]>(() => {
       return [
         '大橋彩香',
         '安齋由香里',
@@ -113,7 +109,14 @@ export default Vue.extend({
       ].map((name: string): string => {
         return `${name}さん`;
       });
-    },
+    });
+
+    return {
+      name,
+      likes,
+      programming,
+      voiceActorNames,
+    };
   },
 });
 </script>

--- a/components/ProfileItem.vue
+++ b/components/ProfileItem.vue
@@ -38,12 +38,6 @@ export default createComponent({
       },
     },
   },
-  setup (props: Props) {
-    return {
-      title: props.title,
-      singleText: props.singleText,
-    };
-  },
 });
 </script>
 

--- a/components/ProfileItem.vue
+++ b/components/ProfileItem.vue
@@ -17,21 +17,32 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import { createComponent } from '@vue/composition-api';
 
-export default Vue.extend({
+interface Props {
+  title: string;
+  singleText: boolean;
+}
+
+export default createComponent({
   name: 'ProfileItem',
   props: {
     title: {
       type: String,
       required: true,
-    } as PropOptions<string>,
+    },
     singleText: {
       type: Boolean,
       default (): boolean {
         return false;
       },
-    } as PropOptions<boolean>,
+    },
+  },
+  setup (props: Props) {
+    return {
+      title: props.title,
+      singleText: props.singleText,
+    };
   },
 });
 </script>

--- a/components/ProjectItem.vue
+++ b/components/ProjectItem.vue
@@ -35,24 +35,30 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import { createComponent, computed } from '@vue/composition-api';
 import { Project } from '~/types';
 
-export default Vue.extend({
+interface Props {
+  project: Project;
+}
+
+export default createComponent({
   name: 'ProjectItem',
   props: {
     project: {
       type: Object,
       required: true,
-    } as PropOptions<Project>,
+    },
   },
-  computed: {
-    hasLinks (): boolean {
-      return this.project.links !== null;
-    },
-    hasTags (): boolean {
-      return this.project.tags !== null;
-    },
+  setup (props: Props) {
+    const project = props.project;
+    const hasLinks = computed<boolean>(() => project.links !== null);
+    const hasTags = computed<boolean>(() => project.tags !== null);
+
+    return {
+      hasLinks,
+      hasTags,
+    };
   },
 });
 </script>

--- a/components/ProjectsContent.vue
+++ b/components/ProjectsContent.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { createComponent, computed } from '@vue/composition-api';
 import ProjectItem from './ProjectItem';
 import { Link, Project } from '~/types';
 
@@ -34,31 +34,13 @@ const gitHubLink = (repo: string): Link => {
   };
 };
 
-export default Vue.extend({
+export default createComponent({
   name: 'ProjectsContent',
   components: {
     ProjectItem,
   },
-  computed: {
-    projectsLength (): number {
-      return this.projects.length;
-    },
-    projectSplitUnit (): number {
-      return 2;
-    },
-    splitProjects (): Project[][] {
-      const projects = this.projects;
-      const projectsLength = this.projectsLength;
-      const splitUnit = this.projectSplitUnit;
-      const splitProject: Project[][] = [];
-
-      for (let i = 0; i < projectsLength; i += splitUnit) {
-        splitProject.push(projects.slice(i, i + splitUnit));
-      }
-
-      return splitProject;
-    },
-    projects (): Project[] {
+  setup () {
+    const projects = computed<Project[]>((): Project[] => {
       return [
         {
           name: 'alt-tl',
@@ -137,7 +119,26 @@ export default Vue.extend({
           tags: ['Vue.js', 'Nuxt.js', 'TypeScript'],
         },
       ];
-    },
+    });
+
+    const projectsLength = computed<number>((): number => projects.value.length);
+    const projectSplitUnit = computed<number>((): number => 2);
+    const splitProjects = computed<Project[][]>((): Project[][] => {
+      const projectsValue = projects.value;
+      const projectsLengthValue = projectsLength.value;
+      const projectSplitUnitValue = projectSplitUnit.value;
+      const splitProject: Project[][] = [];
+
+      for (let i = 0; i < projectsLengthValue; i += projectSplitUnitValue) {
+        splitProject.push(projectsValue.slice(i, i + projectSplitUnitValue));
+      }
+
+      return splitProject;
+    });
+
+    return {
+      splitProjects,
+    };
   },
 });
 </script>

--- a/components/Separator.vue
+++ b/components/Separator.vue
@@ -16,7 +16,7 @@ export default createComponent({
     size: {
       type: String,
       required: false,
-      default () {
+      default (): string {
         return '5';
       },
     },

--- a/components/Separator.vue
+++ b/components/Separator.vue
@@ -4,9 +4,13 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import { createComponent, computed } from '@vue/composition-api';
 
-export default Vue.extend({
+interface Props {
+  size: string;
+}
+
+export default createComponent({
   name: 'Separator',
   props: {
     size: {
@@ -15,11 +19,12 @@ export default Vue.extend({
       default () {
         return '5';
       },
-    } as PropOptions<string>,
+    },
   },
-  computed: {
-    className (): string {
-      const pyClassName = `py-${this.size}`;
+  setup (props: Props) {
+    const size = computed<string>(() => props.size);
+    const className = computed<string>(() => {
+      const pyClassName = `py-${size.value}`;
       const allowClasses = [
         'py-0',
         'py-1',
@@ -43,7 +48,11 @@ export default Vue.extend({
       ];
 
       return allowClasses.includes(pyClassName) ? pyClassName : 'py-5';
-    },
+    });
+
+    return {
+      className,
+    };
   },
 });
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -38,6 +38,7 @@ const config: Configuration = {
   ** Plugins to load before mounting the App
   */
   plugins: [
+    '~/plugins/composition-api.ts',
   ],
 
   /*

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/node": "12.12.26",
     "@typescript-eslint/eslint-plugin": "2.19.0",
     "@typescript-eslint/parser": "2.19.0",
+    "@vue/composition-api": "^0.3.4",
     "eslint": "6.8.0",
     "eslint-config-standard": "14.1.0",
     "eslint-plugin-import": "2.20.1",

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -37,11 +37,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { createComponent, computed } from '@vue/composition-api';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
 
-export default Vue.extend({
+export default createComponent({
   head () {
     return {
       title: this.title,
@@ -51,13 +51,14 @@ export default Vue.extend({
       ],
     };
   },
-  computed: {
-    title (): string {
-      return '404 Not Found';
-    },
-    subtitle (): string {
-      return 'hiroto-k.net';
-    },
+  setup () {
+    const title = computed<string>(() => '404 Not Found');
+    const subtitle = computed<string>(() => 'hiroto-k.net');
+
+    return {
+      title,
+      subtitle,
+    };
   },
   components: {
     Separator,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -38,14 +38,14 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
 import ProfileContent from '~/components/ProfileContent';
 import LinksContent from '~/components/LinksContent';
 import ProjectsContent from '~/components/ProjectsContent';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
+import { createComponent, computed } from '@vue/composition-api';
 
-export default Vue.extend({
+export default createComponent({
   head () {
     return {
       title: this.title,
@@ -58,13 +58,14 @@ export default Vue.extend({
       ],
     };
   },
-  computed: {
-    title (): string {
-      return 'hiroto-k.net';
-    },
-    subTitle (): string {
-      return 'Home page of hiroto-k / hiroxto.';
-    },
+  setup () {
+    const title = computed(() => 'hiroto-k.net');
+    const subTitle = computed(() => 'Home page of hiroto-k / hiroxto.');
+
+    return {
+      title,
+      subTitle,
+    };
   },
   components: {
     ProfileContent,

--- a/plugins/composition-api.ts
+++ b/plugins/composition-api.ts
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+import VueCompositionApi from '@vue/composition-api';
+
+Vue.use(VueCompositionApi);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,6 +1511,13 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
+"@vue/composition-api@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.3.4.tgz#43d2c3377173cfe1d02e51e3342bcf0fbde9c4b6"
+  integrity sha512-aMbg/pEk0PSQAIFyWWLqbAmaCCTx1kFq+49KZslIBJH9Wqos7eEPLtMv4gGxd/EcciBIgfbtUXaXGg/O3mheRA==
+  dependencies:
+    tslib "^1.9.3"
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -8634,7 +8641,7 @@ ts-node@^8.6.2:
     source-map-support "^0.5.6"
     yn "3.1.1"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
## 概要

SFC で Composition API を使うように変更.

Vue.js 3 から標準になる Composition API を, `@vue/composition-api` を使ってサイト全体の SFC で使用する.

## 変更内容

`Vue.extend` を使った書式から, `@vue/composition-api` のメソッドを使った書式に変更.

## 影響範囲

全コンポーネントを書き換え.

- `Vue.extend` を `composition-api` の `createComponent` に置き換え.
- `computed` プロパティを `setup()` 内で設定するように書き換え.

## 動作要件

`@vue/composition-api` が動作する環境.

## 補足

なし