### PR TITLE
コンポーネントの作成で `defineComponent` を使うように変更

### DIFF
--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { createComponent } from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 import { Link } from '~/types';
 
 interface Props {
@@ -31,7 +31,7 @@ interface Props {
   links: Link[];
 }
 
-export default createComponent({
+export default defineComponent({
   name: 'LinkList',
   props: {
     title: {

--- a/components/LinksContent.vue
+++ b/components/LinksContent.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import { createComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 import LinkList from './LinkList';
 import { Link } from '~/types';
 
@@ -27,7 +27,7 @@ interface LinkListProperty {
   links: Link[];
 }
 
-export default createComponent({
+export default defineComponent({
   name: 'LinksContent',
   components: {
     LinkList,

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -9,9 +9,9 @@
 </template>
 
 <script lang="ts">
-import { createComponent } from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 
-export default createComponent({
+export default defineComponent({
   name: 'PageFooter',
 });
 </script>

--- a/components/ProfileContent.vue
+++ b/components/ProfileContent.vue
@@ -67,10 +67,10 @@
 </template>
 
 <script lang="ts">
-import { createComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 import ProfileItem from './ProfileItem';
 
-export default createComponent({
+export default defineComponent({
   name: 'ProfileContent',
   components: {
     ProfileItem,

--- a/components/ProfileItem.vue
+++ b/components/ProfileItem.vue
@@ -17,14 +17,14 @@
 </template>
 
 <script lang="ts">
-import { createComponent } from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 
 interface Props {
   title: string;
   singleText: boolean;
 }
 
-export default createComponent({
+export default defineComponent({
   name: 'ProfileItem',
   props: {
     title: {

--- a/components/ProjectItem.vue
+++ b/components/ProjectItem.vue
@@ -35,14 +35,14 @@
 </template>
 
 <script lang="ts">
-import { createComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 import { Project } from '~/types';
 
 interface Props {
   project: Project;
 }
 
-export default createComponent({
+export default defineComponent({
   name: 'ProjectItem',
   props: {
     project: {

--- a/components/ProjectsContent.vue
+++ b/components/ProjectsContent.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { createComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 import ProjectItem from './ProjectItem';
 import { Link, Project } from '~/types';
 
@@ -34,7 +34,7 @@ const gitHubLink = (repo: string): Link => {
   };
 };
 
-export default createComponent({
+export default defineComponent({
   name: 'ProjectsContent',
   components: {
     ProjectItem,

--- a/components/Separator.vue
+++ b/components/Separator.vue
@@ -4,13 +4,13 @@
 </template>
 
 <script lang="ts">
-import { createComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 
 interface Props {
   size: string;
 }
 
-export default createComponent({
+export default defineComponent({
   name: 'Separator',
   props: {
     size: {

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -37,11 +37,11 @@
 </template>
 
 <script lang="ts">
-import { createComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
 
-export default createComponent({
+export default defineComponent({
   head () {
     return {
       title: this.title,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,9 +43,9 @@ import LinksContent from '~/components/LinksContent';
 import ProjectsContent from '~/components/ProjectsContent';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
-import { createComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 
-export default createComponent({
+export default defineComponent({
   head () {
     return {
       title: this.title,


### PR DESCRIPTION
## 概要

`@vue/composition-api` の v0.4.0 より, `createComponent` が非推奨になり `defineComponent` が推奨されるようになったので変更.

## 変更内容

`*.vue` ファイルの `createComponent` を `defineComponent` に置換.

## 影響範囲

なし

## 動作要件

`@vue/composition-api` v.0.4.0 以上が必要.

## 補足

なし