### PR TITLE
CSS を移動

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -19,10 +19,10 @@ html {
   margin: 0 auto;
 }
 
-.content-base {
+.section-container {
   @apply bg-white py-6 px-6;
 }
 
-.content-title {
+.section-title {
   @apply text-xl text-purple-600 font-bold uppercase font-source-sans-pro;
 }

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -21,6 +21,7 @@ html {
 
 .container {
   margin: 0 auto;
+  @apply min-h-screen text-left;
 }
 
 .page-title {

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -26,15 +26,3 @@ html {
 .content-title {
   @apply text-xl text-purple-600 font-bold uppercase font-source-sans-pro;
 }
-
-.profile-item {
-  @apply mb-2;
-}
-
-.profile-item-title {
-  @apply text-xl text-gray-900 font-medium my-1;
-}
-
-.profile-item-text {
-  @apply text-gray-600;
-}

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -19,6 +19,16 @@ html {
   margin: 0 auto;
 }
 
+.page-title {
+  letter-spacing: 2px;
+  @apply text-gray-800 block;
+}
+
+.page-subtitle {
+  word-spacing: 2px;
+  @apply text-gray-800 pb-8;
+}
+
 .section-container {
   @apply bg-white py-6 px-6;
 }

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -15,6 +15,10 @@ html {
   font-family: 'Source Sans Pro', sans-serif;
 }
 
+.root-container {
+  @apply w-full max-h-full mx-auto px-6 bg-indigo-100;
+}
+
 .container {
   margin: 0 auto;
 }

--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -1,13 +1,13 @@
 <template>
   <section>
-    <h4 v-text="title" class="text-lg text-teal-500 font-bold font-source-sans-pro">
+    <h4 v-text="title" class="links-list-title font-source-sans-pro">
     </h4>
 
     <ul class="list-none p-0 relative">
       <li
         v-for="(link, linksKey) in links"
         :key="linksKey"
-        class="links-list-item text-black bg-gray-100 rounded-lg shadow-lg my-2 p-2 leading-snug"
+        class="links-list-item"
       >
         <a
           v-text="link.name"
@@ -49,7 +49,12 @@ export default defineComponent({
 <style lang="scss" scoped>
 $link-opacity: 0.6;
 
+.links-list-title {
+  @apply text-lg text-teal-500 font-bold;
+}
+
 .links-list-item {
+  @apply text-black bg-gray-100 rounded-lg shadow-lg my-2 p-2 leading-snug;
   border-left: solid 0.5rem #ffa44b;
 }
 

--- a/components/LinksSection.vue
+++ b/components/LinksSection.vue
@@ -1,6 +1,6 @@
 <template>
-  <section class="content-base">
-    <h3 class="content-title">
+  <section class="section-container">
+    <h3 class="section-title">
       Links
     </h3>
 

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <footer class="content-base">
-    <p class="text-xl text-black font-bold font-source-sans-pro">
+    <p class="footer-text font-source-sans-pro">
       © 2019 hiroto-k
     </p>
   </footer>
@@ -13,3 +13,9 @@ export default defineComponent({
   name: 'PageFooter',
 });
 </script>
+
+<style lang="scss" scoped>
+.footer-text {
+  @apply text-xl text-black font-bold;
+}
+</style>

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="content-base">
+  <footer class="section-container">
     <p class="footer-text font-source-sans-pro">
       © 2019 hiroto-k
     </p>

--- a/components/ProfileItem.vue
+++ b/components/ProfileItem.vue
@@ -41,6 +41,16 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+.profile-item {
+  @apply mb-2;
+}
 
+.profile-item-title {
+  @apply text-xl text-gray-900 font-medium my-1;
+}
+
+.profile-item-text {
+  @apply text-gray-600;
+}
 </style>

--- a/components/ProfileSection.vue
+++ b/components/ProfileSection.vue
@@ -6,14 +6,14 @@
       </h3>
 
       <img
-        class="rounded-full h-20 w-20"
+        class="profile-image"
         src="/profile.png"
         alt="Profile image"
       >
     </div>
 
     <div class="mt-4 md:mt-0 md:ml-6">
-      <p class="text-2xl text-gray-900 font-bold pb-4 font-source-sans-pro" v-text="name">
+      <p class="profile-name font-source-sans-pro" v-text="name">
       </p>
 
       <profile-item title="Likes" :single-text="true">
@@ -83,6 +83,12 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+.profile-image {
+  @apply rounded-full h-20 w-20;
+}
 
+.profile-name {
+  @apply text-2xl text-gray-900 font-bold pb-4;
+}
 </style>

--- a/components/ProfileSection.vue
+++ b/components/ProfileSection.vue
@@ -1,7 +1,7 @@
 <template>
-  <section class="content-base md:flex">
+  <section class="section-container md:flex">
     <div class="md:flex-shrink-0">
-      <h3 class="content-title pb-4">
+      <h3 class="section-title pb-4">
         Profile
       </h3>
 

--- a/components/ProjectItem.vue
+++ b/components/ProjectItem.vue
@@ -1,19 +1,19 @@
 <template>
-  <div class="rounded shadow-lg bg-blue-100">
-    <div class="px-6 py-4">
-      <h4 class="font-bold text-xl mb-2 font-source-sans-pro" v-text="project.name">
+  <div class="project-item-container">
+    <div class="project-info">
+      <h4 class="project-name font-source-sans-pro" v-text="project.name">
       </h4>
 
-      <p class="text-gray-700 text-base" v-text="project.description">
+      <p class="project-description" v-text="project.description">
       </p>
     </div>
 
-    <div class="px-6 py-4">
+    <div class="project-links">
       <template v-if="hasLinks">
         <a
           v-for="(link, projectLinksKey) in project.links"
           :key="projectLinksKey"
-          class="project-attributes project-link-item bg-blue-500 rounded font-source-sans-pro"
+          class="project-attributes project-link-item font-source-sans-pro"
           v-text="link.name"
           :href="link.to"
           target="_blank"
@@ -26,7 +26,7 @@
           v-for="(tag, projectTagsKey) in project.tags"
           :key="projectTagsKey"
           v-text="`#${tag}`"
-          class="project-attributes bg-gray-500 rounded-full font-source-sans-pro"
+          class="project-attributes project-tag-item font-source-sans-pro"
         >
         </span>
       </template>
@@ -66,11 +66,29 @@ export default defineComponent({
 <style lang="scss" scoped>
 $link-opacity: 0.6;
 
+.project-item-container {
+  @apply rounded shadow-lg bg-blue-100;
+}
+
+.project-info, .project-links {
+  @apply px-6 py-4;
+}
+
+.project-name {
+  @apply font-bold text-xl mb-2;
+}
+
+.project-description {
+  @apply text-gray-700 text-base;
+}
+
 .project-attributes {
   @apply text-sm text-white font-semibold inline-block px-3 py-1 mr-2 mb-2;
 }
 
 .project-link-item {
+  @apply bg-blue-500 rounded;
+
   &:hover {
     opacity: $link-opacity;
   }
@@ -79,5 +97,9 @@ $link-opacity: 0.6;
     background-color: #38c3e1;
     opacity: $link-opacity;
   }
+}
+
+.project-tag-item{
+  @apply bg-gray-500 rounded-full;
 }
 </style>

--- a/components/ProjectsSection.vue
+++ b/components/ProjectsSection.vue
@@ -1,6 +1,6 @@
 <template>
-  <section class="content-base">
-    <h3 class="content-title">
+  <section class="section-container">
+    <h3 class="section-title">
       Projects
     </h3>
 

--- a/components/ProjectsSection.vue
+++ b/components/ProjectsSection.vue
@@ -7,13 +7,13 @@
     <div
       v-for="(splitProject, splitProjectsKey) in splitProjects"
       :key="splitProjectsKey"
-      class="lg:flex mb-4"
+      class="projects-list lg:flex"
     >
       <project-item
         v-for="(project, projectsKey) in splitProject"
         :key="projectsKey"
         :project="project"
-        class="lg:w-1/2 sm:w-full mx-2 my-4"
+        class="project-item lg:w-1/2 sm:w-full"
       >
       </project-item>
     </div>
@@ -172,3 +172,13 @@ export default defineComponent({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+.projects-list {
+  @apply mb-4;
+}
+
+.project-item {
+  @apply mx-2 my-4;
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full max-h-full mx-auto px-6 bg-indigo-100">
+  <div class="root-container">
     <nuxt>
     </nuxt>
   </div>

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -13,7 +13,7 @@
       >
       </h2>
 
-      <div class="content-base font-source-sans-pro">
+      <div class="section-container font-source-sans-pro">
         <p class="content-text">
           Sorry.
           This page doesn't exist.
@@ -21,7 +21,7 @@
 
         <p class="content-text">
           Please
-          <nuxt-link to="/" class="text-green-600">
+          <nuxt-link to="/" class="text-green-600 hover:text-green-300">
             back to top page.
           </nuxt-link>
         </p>

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container min-h-screen text-left">
+  <div class="container">
     <div class="py-8">
       <h1
         class="text-gray-800 xl:text-4xl lg:text-4xl md:text-4xl sm:text-3xl text-3xl font-source-sans-pro"

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -67,7 +67,7 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .content-text {
   @apply text-lg text-black;
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container min-h-screen text-left">
+  <div class="container">
     <div class="py-8">
       <h1
         class="page-title xl:text-6xl lg:text-6xl md:text-6xl sm:text-5xl text-5xl font-source-sans-pro"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,13 +2,13 @@
   <div class="container min-h-screen text-left">
     <div class="py-8">
       <h1
-        class="title text-gray-800 xl:text-6xl lg:text-6xl md:text-6xl sm:text-5xl text-5xl block font-source-sans-pro"
+        class="title xl:text-6xl lg:text-6xl md:text-6xl sm:text-5xl text-5xl font-source-sans-pro"
         v-text="title"
       >
       </h1>
 
       <h2
-        class="subtitle text-gray-800 xl:text-3xl lg:text-3xl md:text-3xl sm:text-2xl text-2xl pb-8 font-source-sans-pro"
+        class="subtitle xl:text-3xl lg:text-3xl md:text-3xl sm:text-2xl text-2xl font-source-sans-pro"
         v-text="subTitle"
       >
       </h2>
@@ -77,12 +77,14 @@ export default defineComponent({
 });
 </script>
 
-<style>
+<style lang="scss" scoped>
 .title {
   letter-spacing: 2px;
+  @apply text-gray-800 block;
 }
 
 .subtitle {
   word-spacing: 2px;
+  @apply text-gray-800 pb-8;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,13 +2,13 @@
   <div class="container min-h-screen text-left">
     <div class="py-8">
       <h1
-        class="title xl:text-6xl lg:text-6xl md:text-6xl sm:text-5xl text-5xl font-source-sans-pro"
+        class="page-title xl:text-6xl lg:text-6xl md:text-6xl sm:text-5xl text-5xl font-source-sans-pro"
         v-text="title"
       >
       </h1>
 
       <h2
-        class="subtitle xl:text-3xl lg:text-3xl md:text-3xl sm:text-2xl text-2xl font-source-sans-pro"
+        class="page-subtitle xl:text-3xl lg:text-3xl md:text-3xl sm:text-2xl text-2xl font-source-sans-pro"
         v-text="subTitle"
       >
       </h2>
@@ -78,13 +78,4 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.title {
-  letter-spacing: 2px;
-  @apply text-gray-800 block;
-}
-
-.subtitle {
-  word-spacing: 2px;
-  @apply text-gray-800 pb-8;
-}
 </style>


### PR DESCRIPTION
## 概要

Tailwind CSS のユーティリティをテンプレートに直で書いていると, ダークモード対応などで大変なので, `@apply` を使って CSS 側に移動する.

## 変更内容

- 特定のコンポーネントでしか使わないクラスは `assets/css/tailwind.css` から削除
- `<template>` からユーティリティクラスを削除して, Vue の Scoped CSS へ移動して, `@apply` で使うようにする
    - 移行できない物だけはそのまま

## 影響範囲

テンプレート周りと CSS 周りすべて

## 動作要件

なし

## 補足

なし