### PR TITLE
フッターの名前を修正

### DIFF
--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -1,7 +1,7 @@
 <template>
   <footer class="section-container">
     <p class="footer-text font-source-sans-pro">
-      © 2019 hiroto-k
+      © 2019 hiroto-k / hiroxto
     </p>
   </footer>
 </template>


### PR DESCRIPTION
## 概要

フッターの名前を修正.
ProfileSection は両方書いてるのにフッターは片方だけなの謎なので.

## 変更内容

`PageFooter` コンポーネントのテキストを修正

## 影響範囲

なし

## 動作要件

なし

## 補足

なし