### PR TITLE
`lockFileMaintenance` の `automerge` を有効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
+    "automerge": true,
     "schedule": [
       "on sunday"
     ]


### PR DESCRIPTION
## 概要

一々手動でマージするのが面倒なので, `lockFileMaintenance` の `automerge` を有効化

## 変更内容

`renovate.json` ファイルを編集.
`lockFileMaintenance` に `automerge` プロパティを設定.

## 影響範囲

なし

## 動作要件

なし

## 補足

なし