### PR TITLE
Renovate の設定ファイルを更新

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,20 @@
     "config:base"
   ],
   "timezone": "Asia/Tokyo",
-  "schedule": [
-    "on saturday"
-  ],
+  "npm": {
+    "enabled": true,
+    "schedule": [
+      "on saturday"
+    ],
+    "patch": {
+      "automerge": true
+    }
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
     "schedule": [
-      "on sunday"
+      "before 10am on the 20th day of the month"
     ]
   },
   "pin": {
@@ -20,8 +26,5 @@
       "every weekday",
       "every weekend"
     ]
-  },
-  "patch": {
-    "automerge": true
   }
 }


### PR DESCRIPTION
## 概要

Renovate の設定ファイルを更新.
Netlify のビルド時間を節約する.

## 変更内容

npm の更新を土曜日だけ実行.
lock ファイルのメンテナンスを毎月 20日 に実行.

## 影響範囲

なし

## 動作要件

なし

## 補足

なし