### PR TITLE
Node.js のバージョンを 12.18.1 にアップデート

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.15.0]
+        node-version: [12.18.1]
 
     steps:
       - uses: actions/checkout@v1

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   command = "yarn run generate"
 
 [build.environment]
-  NODE_VERSION = "12.15.0"
+  NODE_VERSION = "12.18.1"


### PR DESCRIPTION
## 概要

Node.js のバージョンを 12.18.1 にアップデート.

## 変更内容

GitHub Actions と Netlify の設定ファイル内のバージョンを修正.

## 影響範囲

なし

## 動作要件

なし

## 補足

なし