### PR TITLE
ci: ubuntu-slimへ変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     test:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
 
         steps:
             -   uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## 概要
- GitHub Actions の test ジョブを  から  に変更
- ワークフロー内容を確認し、Docker や sudo を必要としない軽量ジョブであることを前提に置き換え

## 確認内容
- npm run lint:fix
- npm run format:fix
- npm run check:train-number-content
- npm run lint
- npm run format
- npm run check
- npm run test
- npm run build:cf

## 関連 Issue
- なし