### PR TITLE
fix: Swarm コイン規制チェッカーの次回自動判定時刻を修正

### DIFF
--- a/lib/swarm-checkin-regulation-checker/functions.test.ts
+++ b/lib/swarm-checkin-regulation-checker/functions.test.ts
@@ -170,6 +170,23 @@ describe('getNextRefreshAt()', () => {
 
         expect(getNextRefreshAt([], now)).toStrictEqual(new Date('2024-10-01T15:00:00Z'));
     });
+
+    it('一部の条件が規制中でも他条件の非規制判定更新時刻を優先して返すこと', () => {
+        const now = new Date('2024-10-01T03:34:56Z');
+        const checkins = [
+            createCheckin('1', '2024-10-01T03:26:00Z'),
+            createCheckin('2', '2024-10-01T03:27:00Z'),
+            createCheckin('3', '2024-10-01T03:28:00Z'),
+            createCheckin('4', '2024-10-01T03:29:00Z'),
+            createCheckin('5', '2024-10-01T03:30:00Z'),
+            createCheckin('6', '2024-10-01T03:34:00Z'),
+            createCheckin('7', '2024-10-01T03:34:10Z'),
+            createCheckin('8', '2024-10-01T03:34:20Z'),
+            createCheckin('9', '2024-10-01T03:34:30Z'),
+        ];
+
+        expect(getNextRefreshAt(checkins, now)).toStrictEqual(new Date('2024-10-01T03:36:00Z'));
+    });
 });
 
 describe('getAutoFetchComparisonCount()', () => {

--- a/lib/swarm-checkin-regulation-checker/functions.ts
+++ b/lib/swarm-checkin-regulation-checker/functions.ts
@@ -122,32 +122,25 @@ export function getNextRefreshAt(checkins: CheckinItem[], now: Date): Date {
     const m2 = checkLimits(checkins, now, 5, 2, 'minutes');
     const m15 = checkLimits(checkins, now, 8, 15, 'minutes');
     const d1 = checkLimits(checkins, now, 50, 1, 'days');
-    const isLimited = [m2.isLimited, m15.isLimited, d1.isLimited].some(Boolean);
+    const oldestUnLimitingAts = [m2, m15, d1]
+        .filter((result) => !result.isLimited && result.checkins.length > 0)
+        .map((result) => {
+            const [firstCheckin, ...restCheckins] = result.checkins;
+            const oldestCheckin = restCheckins.reduce((oldest, checkin) => {
+                return checkin.createdAt < oldest.createdAt ? checkin : oldest;
+            }, firstCheckin);
 
-    if (!isLimited) {
-        const oldestUnLimitingAts = [m2, m15, d1]
-            .filter((result) => result.checkins.length > 0)
-            .map((result) => {
-                const [firstCheckin, ...restCheckins] = result.checkins;
-                const oldestCheckin = restCheckins.reduce((oldest, checkin) => {
-                    return checkin.createdAt < oldest.createdAt ? checkin : oldest;
-                }, firstCheckin);
-
-                return addPeriod(createdAt2Date(oldestCheckin.createdAt), result.period.value, result.period.unit);
-            })
-            .filter((value) => isAfter(value, now));
-
-        if (oldestUnLimitingAts.length > 0) {
-            return oldestUnLimitingAts.reduce((nearest, candidate) => {
-                return candidate.getTime() < nearest.getTime() ? candidate : nearest;
-            });
-        }
-    }
-
+            return addPeriod(createdAt2Date(oldestCheckin.createdAt), result.period.value, result.period.unit);
+        })
+        .filter((value) => isAfter(value, now));
     const nextMidnight = getNextJstMidnight(now);
-    const candidates = [nextMidnight, m2.unLimitingAt, m15.unLimitingAt, d1.unLimitingAt].filter(
-        (value): value is Date => value != null && isAfter(value, now),
-    );
+    const candidates = [
+        nextMidnight,
+        m2.unLimitingAt,
+        m15.unLimitingAt,
+        d1.unLimitingAt,
+        ...oldestUnLimitingAts,
+    ].filter((value): value is Date => value != null && isAfter(value, now));
 
     return candidates.reduce((nearest, candidate) => {
         return candidate.getTime() < nearest.getTime() ? candidate : nearest;


### PR DESCRIPTION
### Motivation
- `getNextRefreshAt` が「いずれかの条件が規制中」の場合に、他条件の非規制時に来る判定更新時刻（最古チェックインの期限）を候補に含めない実装になっており、例えば `15分に8回` が規制中のときに `2分に5回` の判定更新タイミングで自動判定が走らない問題があった。 

### Description
- `getNextRefreshAt` を修正し、非規制かつ対象チェックインがある各条件について「最古チェックインの期限」を常に候補日時に含めるようにした。 
- 既存の早期分岐を削除して、候補リストに `nextMidnight`, 各条件の `unLimitingAt` と非規制条件の最古期限を統合して最も近い日時を選ぶ方式に変更した。 
- 再発防止のため、該当動作（ある条件が規制中でも別条件の非規制更新時刻を優先する）を検証するユニットテストを追加した。 
- `biome` による整形/修正を実行してコード整備を行った。 

### Testing
- 実行したコマンド: `npm run lint:fix`, `npm run format:fix`, `npm run test`。 
- `npm run lint:fix` は実行され自動修正が適用されました（1 ファイル修正）。 
- `npm run format:fix` は実行されフォーマットが適用されました。 
- `npm run test`（Vitest）を実行し、全テストが成功しました（Test Files 29 passed, Tests 115 passed）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d1448e388330b8ccc1a903674ad2)