### PR TITLE
4sqのAPI呼び出しをNext経由で行う

### DIFF
--- a/app/api/swarm-checkin-regulation-checker/checkins/route.test.ts
+++ b/app/api/swarm-checkin-regulation-checker/checkins/route.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { FoursquareApiError } from '@/lib/swarm-checkin-regulation-checker/foursquare';
+import { GET } from './route';
+
+const { getSelfCheckinsMock } = vi.hoisted(() => ({
+    getSelfCheckinsMock: vi.fn(),
+}));
+
+vi.mock('@/lib/swarm-checkin-regulation-checker/foursquare', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/lib/swarm-checkin-regulation-checker/foursquare')>();
+
+    return {
+        ...actual,
+        FoursquareClient: class {
+            getSelfCheckins = getSelfCheckinsMock;
+        },
+    };
+});
+
+describe('GET /api/swarm-checkin-regulation-checker/checkins', () => {
+    beforeEach(() => {
+        getSelfCheckinsMock.mockReset();
+    });
+
+    test('Authorization ヘッダーがない場合は 401 を返すこと', async () => {
+        const response = await GET(new Request('http://localhost/api/swarm-checkin-regulation-checker/checkins'));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ message: 'Unauthorized' });
+    });
+
+    test('Foursquare のチェックイン一覧を返すこと', async () => {
+        getSelfCheckinsMock.mockResolvedValue([{ id: 'checkin-1' }]);
+
+        const response = await GET(
+            new Request('http://localhost/api/swarm-checkin-regulation-checker/checkins', {
+                headers: {
+                    Authorization: 'Bearer test-token',
+                },
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ checkins: [{ id: 'checkin-1' }] });
+    });
+
+    test('Foursquare API エラー時は status を引き継ぐこと', async () => {
+        getSelfCheckinsMock.mockRejectedValue(new FoursquareApiError(403));
+
+        const response = await GET(
+            new Request('http://localhost/api/swarm-checkin-regulation-checker/checkins', {
+                headers: {
+                    Authorization: 'Bearer invalid-token',
+                },
+            }),
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ message: 'API Call Error: 403' });
+    });
+});

--- a/app/api/swarm-checkin-regulation-checker/checkins/route.ts
+++ b/app/api/swarm-checkin-regulation-checker/checkins/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { FoursquareApiError, FoursquareClient } from '@/lib/swarm-checkin-regulation-checker/foursquare';
+
+const getBearerToken = (authorization: string | null): string | null => {
+    const match = authorization?.match(/^Bearer\s+(.+)$/i);
+    return match?.[1] ?? null;
+};
+
+export async function GET(request: Request) {
+    const token = getBearerToken(request.headers.get('authorization'));
+
+    if (token == null || token === '') {
+        return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const checkins = await new FoursquareClient(token).getSelfCheckins();
+        return NextResponse.json({ checkins });
+    } catch (error) {
+        if (error instanceof FoursquareApiError) {
+            return NextResponse.json({ message: error.message }, { status: error.status });
+        }
+
+        return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+    }
+}

--- a/components/swarm-checkin-regulation-checker/swarm-checkin-regulation-checker-page.test.tsx
+++ b/components/swarm-checkin-regulation-checker/swarm-checkin-regulation-checker-page.test.tsx
@@ -13,8 +13,8 @@ vi.mock('@/hooks/use-current-time', () => ({
     useCurrentTime: () => mockCurrentTime.value,
 }));
 
-vi.mock('@/lib/swarm-checkin-regulation-checker/foursquare', () => ({
-    FoursquareClient: class {
+vi.mock('@/lib/swarm-checkin-regulation-checker/api-client', () => ({
+    SwarmCheckinRegulationCheckerApiClient: class {
         getSelfCheckins = getSelfCheckinsMock;
     },
 }));

--- a/components/swarm-checkin-regulation-checker/swarm-checkin-regulation-checker-page.tsx
+++ b/components/swarm-checkin-regulation-checker/swarm-checkin-regulation-checker-page.tsx
@@ -24,12 +24,12 @@ import { CheckinTable } from '@/components/swarm-checkin-regulation-checker/chec
 import { LimitSummaryCard } from '@/components/swarm-checkin-regulation-checker/limit-summary-card';
 import { useSwarmCheckinRegulationCheckerTokenStore } from '@/components/swarm-checkin-regulation-checker/stores/token-store';
 import { useCurrentTime } from '@/hooks/use-current-time';
+import { SwarmCheckinRegulationCheckerApiClient } from '@/lib/swarm-checkin-regulation-checker/api-client';
 import {
     AUTO_FETCH_INTERVAL_OPTIONS,
     CHECKIN_LIMIT_TITLES,
     RESULT_KEYS,
 } from '@/lib/swarm-checkin-regulation-checker/consts';
-import { FoursquareClient } from '@/lib/swarm-checkin-regulation-checker/foursquare';
 import {
     addPeriod,
     checkAllLimits,
@@ -115,7 +115,7 @@ export const SwarmCheckinRegulationCheckerPage = () => {
             setIsLoading(true);
             setErrorMessage(null);
             try {
-                const client = new FoursquareClient(token);
+                const client = new SwarmCheckinRegulationCheckerApiClient(token);
                 const nextCheckins = await client.getSelfCheckins();
                 const fetchedAt = new Date();
                 const nextResult = checkAllLimits(nextCheckins, fetchedAt);

--- a/lib/swarm-checkin-regulation-checker/api-client.test.ts
+++ b/lib/swarm-checkin-regulation-checker/api-client.test.ts
@@ -1,35 +1,24 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { FoursquareClient } from '@/lib/swarm-checkin-regulation-checker/foursquare';
+import { SwarmCheckinRegulationCheckerApiClient } from '@/lib/swarm-checkin-regulation-checker/api-client';
 
-describe('FoursquareClient', () => {
+describe('SwarmCheckinRegulationCheckerApiClient', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
-    test('認証情報付きで自己チェックイン一覧を取得する', async () => {
+    test('同一オリジンのAPIへ認証情報付きで自己チェックイン一覧を取得する', async () => {
         const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
             ok: true,
             json: async () => ({
-                response: {
-                    checkins: {
-                        items: [{ id: 'checkin-1' }],
-                    },
-                },
+                checkins: [{ id: 'checkin-1' }],
             }),
         } as Response);
 
-        const client = new FoursquareClient('test-token');
+        const client = new SwarmCheckinRegulationCheckerApiClient('test-token');
         const result = await client.getSelfCheckins();
 
         expect(result).toEqual([{ id: 'checkin-1' }]);
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-
-        const [url, options] = fetchMock.mock.calls[0] ?? [];
-        expect(url).toBeInstanceOf(URL);
-        expect((url as URL).toString()).toBe(
-            'https://api.foursquare.com/v2/users/self/checkins?limit=200&v=20221016&lang=ja',
-        );
-        expect(options).toEqual({
+        expect(fetchMock).toHaveBeenCalledWith('/api/swarm-checkin-regulation-checker/checkins', {
             headers: {
                 Authorization: 'Bearer test-token',
             },
@@ -43,7 +32,7 @@ describe('FoursquareClient', () => {
             status: 401,
         } as Response);
 
-        const client = new FoursquareClient('invalid-token');
+        const client = new SwarmCheckinRegulationCheckerApiClient('invalid-token');
 
         await expect(client.getSelfCheckins()).rejects.toThrow('API Call Error: 401');
     });

--- a/lib/swarm-checkin-regulation-checker/api-client.ts
+++ b/lib/swarm-checkin-regulation-checker/api-client.ts
@@ -1,0 +1,25 @@
+import type { CheckinItem } from '@/lib/swarm-checkin-regulation-checker/types';
+
+interface CheckinsResponseBody {
+    checkins: CheckinItem[];
+}
+
+export class SwarmCheckinRegulationCheckerApiClient {
+    constructor(private readonly token: string) {}
+
+    async getSelfCheckins(): Promise<CheckinItem[]> {
+        const response = await fetch('/api/swarm-checkin-regulation-checker/checkins', {
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+            },
+            method: 'GET',
+        });
+
+        if (!response.ok) {
+            throw new Error(`API Call Error: ${response.status}`);
+        }
+
+        const body = (await response.json()) as CheckinsResponseBody;
+        return body.checkins;
+    }
+}

--- a/lib/swarm-checkin-regulation-checker/foursquare.ts
+++ b/lib/swarm-checkin-regulation-checker/foursquare.ts
@@ -1,21 +1,29 @@
 import type { CheckinItem, CheckinResponseBody } from '@/lib/swarm-checkin-regulation-checker/types';
 
+export class FoursquareApiError extends Error {
+    constructor(readonly status: number) {
+        super(`API Call Error: ${status}`);
+    }
+}
+
 export class FoursquareClient {
     constructor(private readonly token: string) {}
 
     async getSelfCheckins(): Promise<CheckinItem[]> {
         const endpoint = new URL('https://api.foursquare.com/v2/users/self/checkins');
-        endpoint.searchParams.set('oauth_token', this.token);
         endpoint.searchParams.set('limit', '200');
         endpoint.searchParams.set('v', '20221016');
         endpoint.searchParams.set('lang', 'ja');
 
         const response = await fetch(endpoint, {
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+            },
             method: 'GET',
         });
 
         if (!response.ok) {
-            throw new Error(`API Call Error: ${response.status}`);
+            throw new FoursquareApiError(response.status);
         }
 
         const body = (await response.json()) as CheckinResponseBody;


### PR DESCRIPTION
# 概要

<!-- PRの概要・背景・対応内容を書く -->

- フロントでの4sqのAPI呼び出しを廃止
- NextにAPIを生やしてAPI経由で行う

## 動作確認

<!-- 行った動作確認の内容を書く -->

## レビュー観点

<!-- PRのレビュー観点を書く -->
