### PR TITLE
[codex] テストを公開挙動ベースに整理

### DIFF
--- a/components/cl-sound/cl-sound-page.test.tsx
+++ b/components/cl-sound/cl-sound-page.test.tsx
@@ -2,42 +2,89 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderWithMantine } from '@/test/test-utils';
-import * as clSoundPageModule from './cl-sound-page';
+import { ClSoundPage } from './cl-sound-page';
+
+class FakeOscillator {
+    type: OscillatorType | null = null;
+    frequency = { value: 0 };
+    connectedDestination: unknown = null;
+    startedAt: number | null = null;
+    stoppedAt: number | null = null;
+
+    connect(destination: unknown) {
+        this.connectedDestination = destination;
+    }
+
+    start(when?: number) {
+        this.startedAt = when ?? null;
+    }
+
+    stop(when?: number) {
+        this.stoppedAt = when ?? null;
+    }
+}
+
+class FakeAudioContext {
+    static latest: FakeAudioContext | null = null;
+
+    currentTime = 10;
+    destination = {};
+    oscillators: FakeOscillator[] = [];
+
+    constructor() {
+        FakeAudioContext.latest = this;
+    }
+
+    createOscillator() {
+        const oscillator = new FakeOscillator();
+        this.oscillators.push(oscillator);
+        return oscillator;
+    }
+}
 
 describe('ClSoundPage', () => {
     afterEach(() => {
-        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        FakeAudioContext.latest = null;
     });
 
-    it('Play Success Tone ボタン押下で playSuccessTone を呼ぶこと', async () => {
+    it('Play Success Tone ボタン押下で成功音を再生すること', async () => {
         const user = userEvent.setup();
-        const playSuccessToneSpy = vi
-            .spyOn(clSoundPageModule.clSoundActions, 'playSuccessTone')
-            .mockImplementation(() => {});
-        const playAlertToneSpy = vi
-            .spyOn(clSoundPageModule.clSoundActions, 'playAlertTone')
-            .mockImplementation(() => {});
-        renderWithMantine(<clSoundPageModule.ClSoundPage />);
+        vi.stubGlobal('AudioContext', FakeAudioContext);
+        renderWithMantine(<ClSoundPage />);
 
         await user.click(screen.getByRole('button', { name: 'Play Success Tone' }));
 
-        expect(playSuccessToneSpy).toHaveBeenCalledTimes(1);
-        expect(playAlertToneSpy).not.toHaveBeenCalled();
+        expect(FakeAudioContext.latest?.oscillators).toMatchObject([
+            {
+                type: 'sine',
+                frequency: { value: 1500 },
+                startedAt: 10,
+                stoppedAt: 10.5,
+            },
+        ]);
     });
 
-    it('Play Alert Tone ボタン押下で playAlertTone を呼ぶこと', async () => {
+    it('Play Alert Tone ボタン押下で警告音を再生すること', async () => {
         const user = userEvent.setup();
-        const playSuccessToneSpy = vi
-            .spyOn(clSoundPageModule.clSoundActions, 'playSuccessTone')
-            .mockImplementation(() => {});
-        const playAlertToneSpy = vi
-            .spyOn(clSoundPageModule.clSoundActions, 'playAlertTone')
-            .mockImplementation(() => {});
-        renderWithMantine(<clSoundPageModule.ClSoundPage />);
+        vi.stubGlobal('AudioContext', FakeAudioContext);
+        renderWithMantine(<ClSoundPage />);
 
         await user.click(screen.getByRole('button', { name: 'Play Alert Tone' }));
 
-        expect(playAlertToneSpy).toHaveBeenCalledTimes(1);
-        expect(playSuccessToneSpy).not.toHaveBeenCalled();
+        expect(FakeAudioContext.latest?.oscillators).toMatchObject([
+            {
+                type: 'sine',
+                frequency: { value: 750 },
+                startedAt: 10,
+                stoppedAt: 10.2,
+            },
+            {
+                type: 'sine',
+                frequency: { value: 750 },
+                startedAt: 10.4,
+                stoppedAt: 10.6,
+            },
+        ]);
     });
 });

--- a/components/fare-ticket-route-planner/control-buttons-ui.test.ts
+++ b/components/fare-ticket-route-planner/control-buttons-ui.test.ts
@@ -1,78 +1,13 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import {
-    createBaseGrayButtonDefinitions,
     createSaveLabels,
     createSaveRoutePayload,
-    createSecondaryButtonDefinitions,
     createUpdateRoutePayload,
     isSameCalendarDate,
 } from '@/components/fare-ticket-route-planner/control-buttons-ui';
 import type { SavedRouteState } from '@/lib/fare-ticket-route-planner/types';
 
 describe('control buttons ui', () => {
-    test('基本ボタンが対応するハンドラーを呼び出すこと', () => {
-        const setDateWithIndex = vi.fn();
-        const openCalendarModal = vi.fn();
-        const reverse = vi.fn();
-        const addRoute = vi.fn();
-
-        const buttons = createBaseGrayButtonDefinitions({
-            setDateWithIndex,
-            openCalendarModal,
-            reverse,
-            addRoute,
-        });
-
-        buttons.find((button) => button.key === 'today')?.onClick?.();
-        expect(setDateWithIndex).toHaveBeenCalledWith(0);
-
-        buttons.find((button) => button.key === 'calendar')?.onClick?.();
-        expect(openCalendarModal).toHaveBeenCalled();
-
-        buttons.find((button) => button.key === 'reverse')?.onClick?.();
-        expect(reverse).toHaveBeenCalled();
-
-        buttons.find((button) => button.key === 'add-route')?.onClick?.();
-        expect(addRoute).toHaveBeenCalledWith(-1);
-    });
-
-    test('補助ボタンで補完切替とリンク設定ができること', () => {
-        const deleteEmptyRoutes = vi.fn();
-        const openClearSettingModal = vi.fn();
-        const openClearAllRoutesModal = vi.fn();
-        const openClearNotesModal = vi.fn();
-        const enableComplete = vi.fn();
-        const disableComplete = vi.fn();
-
-        const buttons = createSecondaryButtonDefinitions({
-            deleteEmptyRoutes,
-            openClearSettingModal,
-            openClearAllRoutesModal,
-            openClearNotesModal,
-            useComplete: true,
-            enableComplete,
-            disableComplete,
-            savedRoutesHref: '/tools/fare-ticket-route-planner/states',
-            openSaveModal: vi.fn(),
-        });
-
-        buttons.find((button) => button.key === 'delete-empty-routes')?.onClick?.();
-        expect(deleteEmptyRoutes).toHaveBeenCalled();
-
-        buttons.find((button) => button.key === 'clear-setting')?.onClick?.();
-        expect(openClearSettingModal).toHaveBeenCalled();
-
-        buttons.find((button) => button.key === 'toggle-complete')?.onClick?.();
-        expect(disableComplete).toHaveBeenCalled();
-        expect(enableComplete).not.toHaveBeenCalled();
-
-        expect(buttons.find((button) => button.key === 'saved-routes')?.href).toBe(
-            '/tools/fare-ticket-route-planner/states',
-        );
-        expect(buttons.find((button) => button.key === 'delete-empty-routes')?.label).toBe('空経路\nクリア');
-        expect(buttons.find((button) => button.key === 'clear-all-routes')?.label).toBe('全経路\nクリア');
-    });
-
     test('保存用ペイロード生成時に現在の経路状態をそのまま返すこと', () => {
         const payload = createSaveRoutePayload({
             type: '片道乗車券',

--- a/components/fare-ticket-route-planner/control-buttons.test.tsx
+++ b/components/fare-ticket-route-planner/control-buttons.test.tsx
@@ -90,6 +90,67 @@ describe('ControlButtons', () => {
         expect(screen.getByRole('button', { name: /補完\s*無効化/ })).toBeInTheDocument();
     });
 
+    test('発着逆転ボタンで出発地と到着地を入れ替えられる', async () => {
+        const user = userEvent.setup();
+        useRouteStateStore.setState({
+            departure: '東京',
+            destination: '博多',
+            routes: [
+                { id: 'route-1', line: '東海道線', station: '名古屋' },
+                { id: 'route-2', line: '山陽線', station: '' },
+            ],
+        });
+
+        renderWithMantine(<ControlButtons />);
+
+        await user.click(screen.getByRole('button', { name: '発着逆転' }));
+
+        expect(useRouteStateStore.getState()).toMatchObject({
+            departure: '博多',
+            destination: '東京',
+            routes: [
+                { id: 'route-2', line: '山陽線', station: '名古屋' },
+                { id: 'route-1', line: '東海道線', station: '' },
+            ],
+        });
+    });
+
+    test('経路追加ボタンで経路を1行追加できる', async () => {
+        const user = userEvent.setup();
+        renderWithMantine(<ControlButtons />);
+
+        await user.click(screen.getByRole('button', { name: '経路追加' }));
+
+        expect(useRouteStateStore.getState().routes).toHaveLength(2);
+    });
+
+    test('空経路クリアボタンで値のない経路を除外できる', async () => {
+        const user = userEvent.setup();
+        useRouteStateStore.setState({
+            routes: [
+                { id: 'empty-route', line: '', station: '' },
+                { id: 'valued-route', line: '東海道線', station: '東京' },
+            ],
+        });
+
+        renderWithMantine(<ControlButtons />);
+
+        await user.click(screen.getByRole('button', { name: /空経路\s*クリア/ }));
+
+        expect(useRouteStateStore.getState().routes).toEqual([
+            { id: 'valued-route', line: '東海道線', station: '東京' },
+        ]);
+    });
+
+    test('保存済み経路へのリンクを表示する', () => {
+        renderWithMantine(<ControlButtons />);
+
+        expect(screen.getByRole('link', { name: /保存済み\s*経路/ })).toHaveAttribute(
+            'href',
+            '/tools/fare-ticket-route-planner/states',
+        );
+    });
+
     test('設定クリアの確認後に種別と駅設定を初期化する', async () => {
         const user = userEvent.setup();
         useRouteStateStore.setState({

--- a/components/fare-ticket-route-planner/stores/input-setting-store.test.ts
+++ b/components/fare-ticket-route-planner/stores/input-setting-store.test.ts
@@ -17,8 +17,4 @@ describe('useInputSettingStore', () => {
         useInputSettingStore.getState().enableComplete();
         expect(useInputSettingStore.getState().useComplete).toBe(true);
     });
-
-    test('永続化キーが input-setting であること', () => {
-        expect(useInputSettingStore.persist.getOptions().name).toBe('input-setting');
-    });
 });

--- a/components/train-number-calc/train-number-calc-page.test.tsx
+++ b/components/train-number-calc/train-number-calc-page.test.tsx
@@ -6,17 +6,17 @@ import { TrainNumberCalcPage } from './train-number-calc-page';
 
 describe('TrainNumberCalcPage', () => {
     it('空入力では結果を表示しないこと', () => {
-        const { container } = renderWithMantine(<TrainNumberCalcPage />);
+        renderWithMantine(<TrainNumberCalcPage />);
 
-        expect(container.querySelector('.mantine-Badge-root')).toBeNull();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
     it('正常な数字入力で列車種別を表示すること', async () => {
         const user = userEvent.setup();
-        const { container } = renderWithMantine(<TrainNumberCalcPage />);
+        renderWithMantine(<TrainNumberCalcPage />);
 
         await user.type(screen.getByLabelText('列車番号'), '1150');
 
-        expect(container.querySelector('.mantine-Badge-root')).toHaveTextContent('高速貨C');
+        expect(screen.getByRole('status')).toHaveTextContent('高速貨C');
     });
 });

--- a/components/train-number-calc/train-number-calc-page.tsx
+++ b/components/train-number-calc/train-number-calc-page.tsx
@@ -55,7 +55,7 @@ export function TrainNumberCalcPage() {
                     />
 
                     {trainType != null ? (
-                        <Badge mt="md" size="xl" color="blue" variant="filled">
+                        <Badge mt="md" size="xl" color="blue" variant="filled" role="status">
                             {trainType}
                         </Badge>
                     ) : null}

--- a/components/train-number/train-number-page.test.tsx
+++ b/components/train-number/train-number-page.test.tsx
@@ -5,7 +5,7 @@ import { TrainNumberPage } from './train-number-page';
 
 describe('TrainNumberPage', () => {
     it('markdown を HTML として表示すること', () => {
-        const { container } = renderWithMantine(
+        renderWithMantine(
             <TrainNumberPage
                 title="2018年3月17日 改正"
                 markdownSource={`# 2018年3月17日 改正
@@ -25,6 +25,6 @@ describe('TrainNumberPage', () => {
         expect(screen.getByRole('link', { name: 'ツール一覧' })).toHaveAttribute('href', '/tools');
         expect(screen.getByRole('link', { name: '列車番号メモ' })).toHaveAttribute('href', '/tools/train-number');
         expect(screen.getByText('東大宮操~回8610M~大宮')).toBeInTheDocument();
-        expect(container.querySelector('article')).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 2, name: '入出場' })).toBeInTheDocument();
     });
 });

--- a/lib/swarm-checkin-regulation-checker/foursquare.test.ts
+++ b/lib/swarm-checkin-regulation-checker/foursquare.test.ts
@@ -26,9 +26,13 @@ describe('FoursquareClient', () => {
 
         const [url, options] = fetchMock.mock.calls[0] ?? [];
         expect(url).toBeInstanceOf(URL);
-        expect((url as URL).toString()).toBe(
-            'https://api.foursquare.com/v2/users/self/checkins?oauth_token=test-token&limit=200&v=20221016&lang=ja',
-        );
+        const endpoint = url as URL;
+        expect(endpoint.origin).toBe('https://api.foursquare.com');
+        expect(endpoint.pathname).toBe('/v2/users/self/checkins');
+        expect(endpoint.searchParams.get('oauth_token')).toBe('test-token');
+        expect(endpoint.searchParams.get('limit')).toBe('200');
+        expect(endpoint.searchParams.get('v')).toBe('20221016');
+        expect(endpoint.searchParams.get('lang')).toBe('ja');
         expect(options).toEqual({ method: 'GET' });
     });
 


### PR DESCRIPTION
## 概要

- `implement-tests` 方針に沿って、実装詳細に依存していた既存テストを公開された振る舞いの検証へ寄せました。
- `cl-sound` は内部メソッド spy ではなく fake `AudioContext` を通して再生されるトーンを検証するようにしました。
- `fare-ticket-route-planner` は UI ヘルパーの handler 呼び出し検証を削り、実際のボタン操作後の store 状態やリンク表示を検証するようにしました。
- `train-number-calc` は結果表示に `role="status"` を付け、Mantine の内部 class に依存しないテストへ変更しました。
- Foursquare API 呼び出しの URL 検証は、クエリ順序に依存しないよう origin/path/query param 単位にしました。

## 確認内容

- `npm run lint:fix`
- `npm run format:fix`
- `npm run test`

## 補足

- `npm run check` は実行しましたが、ignored な `.next/dev/types/validator.ts` が存在しない `app/tools/times-car-estimate-comparison/page.js` を参照して失敗しました。今回の差分起因ではなく、古い Next.js 生成型が残っている可能性があります。